### PR TITLE
Add unit tests for login and logout functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "css-frameworks-ca",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "css-frameworks-ca",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "bootstrap-dark-5": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-frameworks-ca",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Test",
   "main": "index.js",
   "scripts": {

--- a/src/js/api/auth/login.test.js
+++ b/src/js/api/auth/login.test.js
@@ -1,0 +1,19 @@
+import * as mocks from "../../../mocks/index.js";
+import { login } from "./login.js";
+
+describe("login", () => {
+  beforeEach(() => {
+    global.localStorage = mocks.localStorageMock();
+    global.fetch = mocks.fetchMock(mocks.responseMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("stores a token when provided with valid credentials", async () => {
+    await login(mocks.userMock.email, mocks.userMock.password);
+    const token = JSON.parse(localStorage.getItem("token"));
+    expect(token).toEqual(mocks.userMock.accessToken);
+  });
+});

--- a/src/js/api/auth/logout.test.js
+++ b/src/js/api/auth/logout.test.js
@@ -1,0 +1,18 @@
+import * as mocks from "../../../mocks/index.js";
+import { logout } from "./logout.js";
+
+describe("logout", () => {
+  beforeEach(() => {
+    global.localStorage = mocks.localStorageMock();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("clears the token from local storage", () => {
+    localStorage.setItem("token", mocks.userMock.accessToken);
+    logout();
+    expect(localStorage.getItem("token")).toBeNull();
+  });
+});

--- a/src/mocks/fetch.mock.js
+++ b/src/mocks/fetch.mock.js
@@ -1,0 +1,8 @@
+export const fetchMock = (response = {}, status = 200, statusText = "OK") => {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status: status,
+    statusText: statusText,
+    json: () => Promise.resolve(response),
+  });
+};

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -1,0 +1,4 @@
+export * from "./fetch.mock.js";
+export * from "./localStorage.mock.js";
+export * from "./response.mock.js";
+export * from "./user.mock.js";

--- a/src/mocks/localStorage.mock.js
+++ b/src/mocks/localStorage.mock.js
@@ -1,0 +1,10 @@
+export const localStorageMock = () => {
+  let store = {};
+
+  return {
+    setItem: jest.fn((key, value) => (store[key] = value.toString())),
+    getItem: jest.fn((key) => store[key] || null),
+    removeItem: jest.fn((key) => delete store[key]),
+    clear: jest.fn(() => (store = {})),
+  };
+};

--- a/src/mocks/response.mock.js
+++ b/src/mocks/response.mock.js
@@ -1,0 +1,9 @@
+import { userMock } from "./user.mock.js";
+
+export const responseMock = {
+  name: userMock.name,
+  email: userMock.email,
+  avatar: userMock.avatar,
+  banner: userMock.banner,
+  accessToken: userMock.accessToken,
+};

--- a/src/mocks/user.mock.js
+++ b/src/mocks/user.mock.js
@@ -1,0 +1,8 @@
+export const userMock = {
+  name: "testuser",
+  email: "test@stud.noroff.no",
+  password: "testpassword123",
+  avatar: "",
+  banner: "",
+  accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9....",
+};


### PR DESCRIPTION
This pull request adds unit tests for the login and logout functions. Additionally, mock files have been included for testing purposes.

**Unit Test Cases Covered:**

- The login function stores a token when provided with valid credentials.
- The logout function clears the token from browser storage.